### PR TITLE
add support for detecting FIVEOHTHREE_IGNORE_LOCK when it's set fr…

### DIFF
--- a/src/LockGuard.php
+++ b/src/LockGuard.php
@@ -22,7 +22,7 @@ abstract class LockGuard
      */
     public static function lockFileExists(string $path): bool
     {
-        $ignoreFlag = (bool) ($_ENV['FIVEOHTHREE_IGNORE_LOCK'] ?? false);
+        $ignoreFlag = (bool) ($_ENV['FIVEOHTHREE_IGNORE_LOCK'] ?? getenv('FIVEOHTHREE_IGNORE_LOCK') ?? false);
         if ($ignoreFlag === true) {
             return false;
         }

--- a/tests/FiveOhThreeTest.php
+++ b/tests/FiveOhThreeTest.php
@@ -15,6 +15,7 @@ class FiveOhThreeTest extends TestCase
 
         // ensure each test gets a clean env
         unset($_ENV['FIVEOHTHREE_IGNORE_LOCK']);
+        putenv('FIVEOHTHREE_IGNORE_LOCK');
     }
 
     public function test_lockFileExists()
@@ -24,6 +25,12 @@ class FiveOhThreeTest extends TestCase
 
         $_ENV['FIVEOHTHREE_IGNORE_LOCK'] = 'true';
         $this->assertFalse(LockGuard::lockFileExists(__FILE__), 'Lock file should be ignored');
+
+        unset($_ENV['FIVEOHTHREE_IGNORE_LOCK']);
+        $this->assertTrue(LockGuard::lockFileExists(__FILE__), 'Lock file should be detected again');
+
+        putenv('FIVEOHTHREE_IGNORE_LOCK=true');
+        $this->assertFalse(LockGuard::lockFileExists(__FILE__), 'Lock file should be ignored again');
     }
 
     public function test_checkAndThrow()


### PR DESCRIPTION
This adds a check that uses `getenv` to get the value of `FIVEOHTHREE_IGNORE_LOCK` because if the var is set from an OS-level environment variable, it will not be reflected in `$_ENV`.
This will ease the usage in deployment script that might be lauched after `export FIVEOHTHREE_IGNORE_LOCK=true` or with `FIVEOHTHREE_IGNORE_LOCK=true ./deployment-script.sh`